### PR TITLE
Use appropriate configuration schema.

### DIFF
--- a/config/install/sessionize_embed_block.settings.yml
+++ b/config/install/sessionize_embed_block.settings.yml
@@ -1,2 +1,3 @@
 embed_id: 6mh71zh8
-embed_style: 0
+embed_style: SmartGrid
+

--- a/config/schema/sessionize_embed_block.schema.yml
+++ b/config/schema/sessionize_embed_block.schema.yml
@@ -6,5 +6,5 @@ sessionize_embed_block.settings:
       type: string
       label: Sessionize Embed ID
     embed_style:
-      type: integer
+      type: string
       label: Sessionize Embed Style


### PR DESCRIPTION
# Proof of Concept (version 0.0.1)

Initial release of basic Sessionize embed block:

![Sessionize Embed in Drupal 8](https://user-images.githubusercontent.com/1103978/134827378-0da4dce4-1fe7-4368-9cf8-d8693d0c59b2.png)

## @todo for official public 0.1.0 release

- Add a `composer.json` to include this more easily in Drupal projects
- [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and start Semantic Versioning branch 0.1.0
- Include config form in Block class -- this is easy, I should have done it already
- Release module on Drupal.org

## @todo post-launch enhancements
- Expose block config as AJAX overlay to switch ID and style without leaving the page
- Extend module from Embed to full API integration